### PR TITLE
Update rag_using_pinecone.ipynb

### DIFF
--- a/third_party/Pinecone/rag_using_pinecone.ipynb
+++ b/third_party/Pinecone/rag_using_pinecone.ipynb
@@ -430,7 +430,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "keyword_json = \"{\" + get_completion(create_keyword_prompt(query))\n",
+    "keyword_json = \"{\" + get_completion(create_keyword_prompt(USER_QUESTION))\n",
     "print(keyword_json)"
    ]
   },


### PR DESCRIPTION
Fix "'query' is not defined" by pointing to the user question string.