### PR TITLE
Escape for valid notebook

### DIFF
--- a/tool_use/calculator_tool.ipynb
+++ b/tool_use/calculator_tool.ipynb
@@ -58,7 +58,7 @@
     "\n",
     "def calculate(expression):\n",
     "    # Remove any non-digit or non-operator characters from the expression\n",
-    "    expression = re.sub(r'[^0-9+\-*/().]', '', expression)\n",
+    "    expression = re.sub(r'[^0-9+\\-*/().]', '', expression)\n",
     "    \n",
     "    try:\n",
     "        # Evaluate the expression using the built-in eval() function\n",


### PR DESCRIPTION
Without this escape, the notebook [renders as](https://carsonkahn.cloud/QYGW6hPq):

![image](https://github.com/anthropics/anthropic-cookbook/assets/12088585/9cc5ed57-99d5-459f-ae37-e44be5775a05)
