### PR TITLE
link to API key creation location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Anthropic Cookbook
 
-The Anthropic Cookbook provides code and guides designed to help developers build with Claude, offering copy-able code snippets that you can easily integrate into your own projects.
+The [Anthropic](https://www.anthropic.com) Cookbook provides code and guides designed to help developers build with Claude, offering copy-able code snippets that you can easily integrate into your own projects.
 
 ## Prerequisites
 
-To make the most of the examples in this cookbook, you'll need an Anthropic API key (sign up for free [here](https://www.anthropic.com)).
+To make the most of the examples in this cookbook, you'll need an [Anthropic API key](https://console.anthropic.com/settings/keys) (sign up for free [here](https://www.anthropic.com)).
 
 While the code examples are primarily written in Python, the concepts can be adapted to any programming language that supports interaction with the Anthropic API.
 


### PR DESCRIPTION
The link to the home page after the mention of the API is not the most useful link to give. 
When you're looking for the place to create API keys, you want a direct link to that not to the home page.  

I get that you might want to route people through the home page for some reason so I left that link in tact (although I think it would be better to remove it).  

However I also added the direct link to the API keys, and added a link to the home page earlier, in preparation for possibly removing or changing the link marked "here" in the phrase "sign up for free here".   I think the only value remaining in the text surrounding that link is the fact that it expresses that the sign up is free.  I wanted to make minimal changes, but I think it would be better if that could be expressed differently.  Let me know if you'd like me to propose a slightly more complete set of changes.