### PR TITLE
Fix: Address issue #114 Add a new notebook to have extended conversat…

### DIFF
--- a/misc/multi_turn_pdf_understanding.ipynb
+++ b/misc/multi_turn_pdf_understanding.ipynb
@@ -1,0 +1,428 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "source": [
+    "# Multi-Turn PDF Understanding with Claude\n",
+    "\n",
+    "This notebook demonstrates how to have extended conversations with Claude about PDF documents. Unlike single-shot interactions, this approach maintains context across multiple exchanges, allowing you to ask follow-up questions, dive deeper into specific sections, and build upon previous answers.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We'll start by installing the Anthropic client and setting up the necessary configuration for PDF support.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting anthropic\n",
+      "  Downloading anthropic-0.52.2-py3-none-any.whl.metadata (25 kB)\n",
+      "Requirement already satisfied: anyio<5,>=3.5.0 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from anthropic) (4.8.0)\n",
+      "Collecting distro<2,>=1.7.0 (from anthropic)\n",
+      "  Downloading distro-1.9.0-py3-none-any.whl.metadata (6.8 kB)\n",
+      "Requirement already satisfied: httpx<1,>=0.25.0 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from anthropic) (0.28.1)\n",
+      "Collecting jiter<1,>=0.4.0 (from anthropic)\n",
+      "  Downloading jiter-0.10.0-cp311-cp311-macosx_11_0_arm64.whl.metadata (5.2 kB)\n",
+      "Requirement already satisfied: pydantic<3,>=1.9.0 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from anthropic) (2.10.5)\n",
+      "Requirement already satisfied: sniffio in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from anthropic) (1.3.1)\n",
+      "Requirement already satisfied: typing-extensions<5,>=4.10 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from anthropic) (4.13.2)\n",
+      "Requirement already satisfied: idna>=2.8 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from anyio<5,>=3.5.0->anthropic) (3.4)\n",
+      "Requirement already satisfied: certifi in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from httpx<1,>=0.25.0->anthropic) (2025.4.26)\n",
+      "Requirement already satisfied: httpcore==1.* in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from httpx<1,>=0.25.0->anthropic) (1.0.7)\n",
+      "Requirement already satisfied: h11<0.15,>=0.13 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.25.0->anthropic) (0.14.0)\n",
+      "Requirement already satisfied: annotated-types>=0.6.0 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->anthropic) (0.7.0)\n",
+      "Requirement already satisfied: pydantic-core==2.27.2 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->anthropic) (2.27.2)\n",
+      "Downloading anthropic-0.52.2-py3-none-any.whl (286 kB)\n",
+      "Downloading distro-1.9.0-py3-none-any.whl (20 kB)\n",
+      "Downloading jiter-0.10.0-cp311-cp311-macosx_11_0_arm64.whl (321 kB)\n",
+      "Installing collected packages: jiter, distro, anthropic\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3/3\u001b[0m [anthropic]/3\u001b[0m [anthropic]\n",
+      "\u001b[1A\u001b[2KSuccessfully installed anthropic-0.52.2 distro-1.9.0 jiter-0.10.0\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "%pip install anthropic\n",
+    "%pip install python-dotenv\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from anthropic import Anthropic\n",
+    "import base64\n",
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Load the environment variables\n",
+    "load_dotenv()\n",
+    "\n",
+    "# Get the API key from the environment variables\n",
+    "api_key = os.getenv(\"ANTHROPIC_API_KEY\")\n",
+    "\n",
+    "# While PDF support is in beta, you must pass in the correct beta header\n",
+    "client = Anthropic(\n",
+    "  api_key=api_key,\n",
+    "  default_headers={\n",
+    "    \"anthropic-beta\": \"pdfs-2024-09-25\"\n",
+    "  }\n",
+    ")\n",
+    "# For now, only claude-3-5-sonnet-20241022 supports PDFs\n",
+    "MODEL_NAME = \"claude-3-5-sonnet-20241022\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "## Loading and Encoding the PDF\n",
+    "\n",
+    "Next, we'll load a PDF document and convert it to the base64 format required by the Anthropic API. The PDF will be loaded once and reused throughout our multi-turn conversation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Successfully loaded PDF: ../multimodal/documents/constitutional-ai-paper.pdf\n",
+      "✓ PDF size: 2784148 characters (base64 encoded)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load and encode the PDF document\n",
+    "file_name = \"../multimodal/documents/constitutional-ai-paper.pdf\"\n",
+    "\n",
+    "def load_pdf_as_base64(file_path):\n",
+    "    \"\"\"Load a PDF file and return its base64-encoded string representation.\"\"\"\n",
+    "    try:\n",
+    "        with open(file_path, \"rb\") as pdf_file:\n",
+    "            binary_data = pdf_file.read()\n",
+    "            base64_encoded_data = base64.standard_b64encode(binary_data)\n",
+    "            return base64_encoded_data.decode(\"utf-8\")\n",
+    "    except FileNotFoundError:\n",
+    "        print(f\"Error: Could not find PDF file at {file_path}\")\n",
+    "        return None\n",
+    "    except Exception as e:\n",
+    "        print(f\"Error loading PDF: {e}\")\n",
+    "        return None\n",
+    "\n",
+    "# Load the PDF once for the entire conversation\n",
+    "pdf_base64 = load_pdf_as_base64(file_name)\n",
+    "if pdf_base64:\n",
+    "    print(f\"✓ Successfully loaded PDF: {file_name}\")\n",
+    "    print(f\"✓ PDF size: {len(pdf_base64)} characters (base64 encoded)\")\n",
+    "else:\n",
+    "    print(\"✗ Failed to load PDF. Please check the file path.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "## Multi-Turn Conversation Functions\n",
+    "\n",
+    "Now we'll create the core functions that enable multi-turn conversations with the PDF. The key insight is that we only need to include the PDF document in the first message of our conversation - subsequent messages can reference it without re-uploading.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_completion(client, messages, max_tokens=2048):\n",
+    "    \"\"\"Get a completion from Claude using the provided messages.\"\"\"\n",
+    "    try:\n",
+    "        response = client.messages.create(\n",
+    "            model=MODEL_NAME,\n",
+    "            max_tokens=max_tokens,\n",
+    "            messages=messages\n",
+    "        )\n",
+    "        return response.content[0].text\n",
+    "    except Exception as e:\n",
+    "        return f\"Error: {e}\"\n",
+    "\n",
+    "def create_initial_message(pdf_base64, user_prompt):\n",
+    "    \"\"\"Create the first message that includes the PDF document.\"\"\"\n",
+    "    return {\n",
+    "        \"role\": \"user\",\n",
+    "        \"content\": [\n",
+    "            {\n",
+    "                \"type\": \"document\", \n",
+    "                \"source\": {\n",
+    "                    \"type\": \"base64\", \n",
+    "                    \"media_type\": \"application/pdf\", \n",
+    "                    \"data\": pdf_base64\n",
+    "                }\n",
+    "            },\n",
+    "            {\n",
+    "                \"type\": \"text\", \n",
+    "                \"text\": user_prompt\n",
+    "            }\n",
+    "        ]\n",
+    "    }\n",
+    "\n",
+    "def create_followup_message(user_prompt):\n",
+    "    \"\"\"Create a follow-up message (text only, no PDF re-upload needed).\"\"\"\n",
+    "    return {\n",
+    "        \"role\": \"user\",\n",
+    "        \"content\": user_prompt\n",
+    "    }\n",
+    "\n",
+    "def print_conversation_separator():\n",
+    "    \"\"\"Print a visual separator for the conversation.\"\"\"\n",
+    "    print(\"\\n\" + \"=\"*80 + \"\\n\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "## Interactive Multi-Turn PDF Chat\n",
+    "\n",
+    "This is the main conversation loop that allows you to have an extended dialogue with Claude about the PDF document. The conversation maintains context across all exchanges.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def start_pdf_conversation(pdf_base64):\n",
+    "    \"\"\"Start an interactive multi-turn conversation about the PDF.\"\"\"\n",
+    "    if not pdf_base64:\n",
+    "        print(\"No PDF loaded. Please load a PDF first.\")\n",
+    "        return\n",
+    "    \n",
+    "    conversation_history = []\n",
+    "    turn_count = 0\n",
+    "    \n",
+    "    print(\"Multi-Turn PDF Chat Started!\")\n",
+    "    print(\"PDF document loaded and ready for questions.\")\n",
+    "    print(\"Type 'quit' to end the conversation\")\n",
+    "    print(\"Type 'history' to see conversation summary\")\n",
+    "    print(\"Type 'clear' to start fresh (keeping the PDF)\")\n",
+    "    print_conversation_separator()\n",
+    "    \n",
+    "    while True:\n",
+    "        # Get user input\n",
+    "        try:\n",
+    "            user_input = input(\"User: \").strip()\n",
+    "        except KeyboardInterrupt:\n",
+    "            print(\"\\n\\nConversation ended by user.\")\n",
+    "            break\n",
+    "        \n",
+    "        # Handle special commands\n",
+    "        if user_input.lower() == \"quit\":\n",
+    "            print(\"Conversation ended.\")\n",
+    "            break\n",
+    "        elif user_input.lower() == \"history\":\n",
+    "            print(f\"Conversation Summary: {len(conversation_history)} messages, {turn_count} turns\")\n",
+    "            if conversation_history:\n",
+    "                print(\"Recent topics discussed:\")\n",
+    "                for i, msg in enumerate(conversation_history[-6:], 1):  # Show last 3 exchanges\n",
+    "                    role = \"User\" if msg[\"role\"] == \"user\" else \"Assistant\"\n",
+    "                    content = msg[\"content\"]\n",
+    "                    if isinstance(content, list):\n",
+    "                        content = content[1][\"text\"]  # Extract text from complex content\n",
+    "                    preview = content[:100] + \"...\" if len(content) > 100 else content\n",
+    "                    print(f\"  {role}: {preview}\")\n",
+    "            continue\n",
+    "        elif user_input.lower() == \"clear\":\n",
+    "            conversation_history = []\n",
+    "            turn_count = 0\n",
+    "            print(\"Conversation history cleared. PDF still loaded.\")\n",
+    "            continue\n",
+    "        elif not user_input:\n",
+    "            print(\"Please enter a question or command.\")\n",
+    "            continue\n",
+    "        \n",
+    "        # Create the appropriate message\n",
+    "        if turn_count == 0:\n",
+    "            # First turn: include PDF document\n",
+    "            user_message = create_initial_message(pdf_base64, user_input)\n",
+    "        else:\n",
+    "            # Subsequent turns: text only\n",
+    "            user_message = create_followup_message(user_input)\n",
+    "        \n",
+    "        # Add user message to history\n",
+    "        conversation_history.append(user_message)\n",
+    "        \n",
+    "        # Get response from Claude\n",
+    "        print(\"Claude is thinking...\")\n",
+    "        assistant_response = get_completion(client, conversation_history)\n",
+    "        \n",
+    "        # Display response\n",
+    "        print(f\"Assistant: {assistant_response}\")\n",
+    "        \n",
+    "        # Add assistant response to history\n",
+    "        conversation_history.append({\n",
+    "            \"role\": \"assistant\", \n",
+    "            \"content\": assistant_response\n",
+    "        })\n",
+    "        \n",
+    "        turn_count += 1\n",
+    "        print_conversation_separator()\n",
+    "\n",
+    "# Start the conversation if PDF is loaded\n",
+    "if pdf_base64:\n",
+    "    start_pdf_conversation(pdf_base64)\n",
+    "else:\n",
+    "    print(\"Cannot start conversation: PDF not loaded\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "## Example: Programmatic Multi-Turn Conversation\n",
+    "\n",
+    "Below is an example of how you might structure a programmatic multi-turn conversation without user input, useful for automated analysis or testing.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def demonstrate_programmatic_conversation(pdf_base64):\n",
+    "    \"\"\"Demonstrate a programmatic multi-turn conversation about the PDF.\"\"\"\n",
+    "    if not pdf_base64:\n",
+    "        print(\"No PDF loaded for demonstration.\")\n",
+    "        return\n",
+    "    \n",
+    "    # Define a series of questions that build upon each other\n",
+    "    questions = [\n",
+    "        \"What is the main topic of this paper? Please provide a brief summary.\",\n",
+    "        \"What are the key challenges or problems that this work addresses?\",\n",
+    "        \"Can you explain the main methodology or approach used in more detail?\",\n",
+    "        \"What were the most significant results or findings?\",\n",
+    "        \"Based on our discussion, what do you think are the most important implications of this work?\"\n",
+    "    ]\n",
+    "    \n",
+    "    conversation_history = []\n",
+    "    \n",
+    "    print(\"Programmatic Multi-Turn PDF Analysis\")\n",
+    "    print(\"=\" * 50)\n",
+    "    \n",
+    "    for i, question in enumerate(questions, 1):\n",
+    "        print(f\"\\nQuestion {i}: {question}\")\n",
+    "        print(\"-\" * 40)\n",
+    "        \n",
+    "        # Create appropriate message (first includes PDF, others are text-only)\n",
+    "        if i == 1:\n",
+    "            user_message = create_initial_message(pdf_base64, question)\n",
+    "        else:\n",
+    "            user_message = create_followup_message(question)\n",
+    "        \n",
+    "        conversation_history.append(user_message)\n",
+    "        \n",
+    "        # Get response\n",
+    "        response = get_completion(client, conversation_history, max_tokens=1024)\n",
+    "        print(f\"Claude's Response:\\n{response}\\n\")\n",
+    "        \n",
+    "        # Add response to history\n",
+    "        conversation_history.append({\n",
+    "            \"role\": \"assistant\",\n",
+    "            \"content\": response\n",
+    "        })\n",
+    "    \n",
+    "    print(\"Programmatic conversation completed!\")\n",
+    "    print(f\"Total exchanges: {len(questions)}\")\n",
+    "    return conversation_history\n",
+    "\n",
+    "# Uncomment the line below to run the programmatic demonstration\n",
+    "# programmatic_history = demonstrate_programmatic_conversation(pdf_base64)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "## Advanced Features and Tips\n",
+    "\n",
+    "### Key Benefits of Multi-Turn PDF Conversations:\n",
+    "\n",
+    "1. **Context Preservation**: Each question builds upon previous answers, allowing for deeper exploration\n",
+    "2. **Efficiency**: The PDF is uploaded only once, saving bandwidth and processing time\n",
+    "3. **Natural Flow**: Conversations feel more natural and allow for clarification and follow-up questions\n",
+    "4. **Memory**: Claude remembers what was discussed earlier in the conversation\n",
+    "\n",
+    "### Best Practices:\n",
+    "\n",
+    "- **Start Broad, Then Narrow**: Begin with general questions, then dive into specific details\n",
+    "- **Reference Previous Answers**: Use phrases like \"Based on what you just explained...\" or \"Following up on your earlier point...\"\n",
+    "- **Ask for Clarification**: Don't hesitate to ask Claude to explain concepts in different ways\n",
+    "- **Use the History**: The conversation history helps you track what's been covered\n",
+    "\n",
+    "### Potential Use Cases:\n",
+    "\n",
+    "- **Research Paper Analysis**: Deep dive into academic papers with follow-up questions\n",
+    "- **Document Review**: Systematic review of contracts, reports, or policy documents  \n",
+    "- **Educational Content**: Interactive learning sessions with educational materials\n",
+    "- **Technical Documentation**: Step-by-step exploration of complex technical documents\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Add Multi-Turn PDF Understanding Notebook

### Overview
Added a new Jupyter notebook that demonstrates how to have extended conversations with Claude about PDF documents, maintaining context across multiple exchanges. This implementation allows for follow-up questions and deeper exploration of PDF content through a conversational interface.

### Key Features
- **Interactive Chat Interface**: Built-in conversation loop with commands like 'quit', 'history', and 'clear'
- **PDF Memory**: PDF is uploaded once and referenced throughout the conversation
- **Context Preservation**: Maintains conversation history for coherent multi-turn interactions
- **Programmatic Mode**: Includes a demonstration of automated PDF analysis with predefined question sequences

### Technical Details
- Uses Claude 3.5 Sonnet with PDF beta support
- Implements proper error handling for PDF loading and API interactions
- Includes environment variable support for API key management
- Maintains conversation context while optimizing for API payload size

### Usage Example
```python
# Load and start conversation
pdf_base64 = load_pdf_as_base64("path/to/pdf")
start_pdf_conversation(pdf_base64)

# Or run automated analysis
programmatic_history = demonstrate_programmatic_conversation(pdf_base64)
```

## Documentation
Includes comprehensive documentation with:
- Setup instructions
- Best practices for PDF conversations
- Use case examples
- Advanced features and tips