### PR TITLE
Fix: Update prompt caching to use standard API endpoint

### DIFF
--- a/skills/contextual-embeddings/guide.ipynb
+++ b/skills/contextual-embeddings/guide.ipynb
@@ -458,7 +458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -491,7 +491,7 @@
     "\"\"\"\n",
     "\n",
     "def situate_context(doc: str, chunk: str) -> str:\n",
-    "    response = client.beta.prompt_caching.messages.create(\n",
+    "    response = client.messages.create(\n",
     "        model=\"claude-3-haiku-20240307\",\n",
     "        max_tokens=1024,\n",
     "        temperature=0.0,\n",


### PR DESCRIPTION
## Problem
The prompt caching example in [_contextual-embeddings_/guide.ipynb] uses deprecated API syntax that causes errors:
```python
# This fails with AttributeError: 'Beta' object has no attribute 'prompt_caching'
client.beta.prompt_caching.messages.create(...)
```

## Solution
Updated to use the current standard API endpoint for prompt caching:
```python
client.messages.create(
    ...,
    extra_headers={"anthropic-beta": "prompt-caching-2024-07-31"}
)
```

## Changes Made
- Replaced `client.beta.prompt_caching.messages.create()` with `client.messages.create()`
- Kept the required `extra_headers` for prompt caching functionality
