### PR TITLE
Fix: Correct retrieve function call in answer_query_level_two for evaluation consistency

### DIFF
--- a/skills/retrieval_augmented_generation/guide.ipynb
+++ b/skills/retrieval_augmented_generation/guide.ipynb
@@ -3447,7 +3447,7 @@
     "    return results, context\n",
     "\n",
     "def answer_query_level_two(query, db):\n",
-    "    documents, context = retrieve_base(query, db)\n",
+    "    documents, context = retrieve_level_two(query, db)\n",
     "    prompt = f\"\"\"\n",
     "    You have been tasked with helping us to answer the following query: \n",
     "    <query>\n",


### PR DESCRIPTION
## 🐛 Bug Description

Fixed an inconsistency in the RAG evaluation system where `answer_query_level_two` was incorrectly calling `retrieve_base` instead of `retrieve_level_two`.

## 🔍 Problem Analysis

### Issue Impact:
- **Evaluation Inconsistency**: Retrieval evaluation used `retrieve_level_two` but end-to-end evaluation used `answer_query_level_two` which internally called `retrieve_base`
- **Performance Metrics Distortion**: Level Two improvements weren't properly tested in end-to-end evaluation  
- **Function Hierarchy Violation**: Broke the intended level-based architecture

### Function Call Pattern:
| Function Level | Expected Retrieval | Before This Fix | After This Fix |
|---|---|---|---|
| Base | `retrieve_base` | ✅ `retrieve_base` | ✅ `retrieve_base` |
| Level Two | `retrieve_level_two` | ❌ `retrieve_base` | ✅ `retrieve_level_two` |
| Advanced | `retrieve_advanced` | ✅ `retrieve_advanced` | ✅ `retrieve_advanced` |

## 🔧 Solution

**File**: `skills/retrieval_augmented_generation/guide.ipynb`  
**Line**: 3450

```python
# Before
def answer_query_level_two(query, db):
    documents, context = retrieve_base(query, db)  # ❌ Wrong

# After  
def answer_query_level_two(query, db):
    documents, context = retrieve_level_two(query, db)  # ✅ Correct
```