### PR TITLE
Remove duplicate model usage check from notebook-review

### DIFF
--- a/.claude/commands/notebook-review.md
+++ b/.claude/commands/notebook-review.md
@@ -5,14 +5,6 @@ description: Comprehensive review of Jupyter notebooks and Python scripts
 
 Review the changes to Jupyter notebooks and Python scripts in this PR. Please check for:
 
-## Model Usage
-Verify all Claude model references against the current list at:
-https://docs.anthropic.com/en/docs/about-claude/models/overview.md
-- Flag any deprecated models (older Sonnet 3.5, Opus 3 versions)
-- Flag any internal/non-public model names
-- Suggest current alternatives when issues found
-- Recommend aliases ending in -latest for stability
-
 ## Code Quality
 - Python code follows PEP 8 conventions
 - Proper error handling


### PR DESCRIPTION
The `model-check` command already handles model validation for all notebooks and Python files - `notebook-review` doesn't need to do a separate check on models.

model-check triggers on:
```
paths:
  - '**/*.ipynb'
  - '**.py'
  - '**.md'
```

notebook-review triggers on:
```
paths:
  - '**/*.ipynb'
  - 'pyproject.toml'
  - 'uv.lock'
  - 'scripts/**/*.py'
```

So anything model-related that triggers `notebook-review` will also trigger `model-check`